### PR TITLE
Rename :term_id to :term

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -15,6 +15,6 @@ MembersPage.new(
   response: Scraped::Request.new(url: 'http://house.gov.by/ru/deputies-ru/').response
 ).member_urls.each do |member_url|
   response = Scraped::Request.new(url: member_url).response
-  data = MemberPage.new(response: response).to_h.merge(term_id: 6)
-  ScraperWiki.save_sqlite(%i(id term_id), data)
+  data = MemberPage.new(response: response).to_h.merge(term: 6)
+  ScraperWiki.save_sqlite(%i(id term), data)
 end


### PR DESCRIPTION
Part of: https://github.com/everypolitician/everypolitician-data/issues/26546

The scraper is currently recording the term as `:term_id`. This should be `:term` according to the EP spec: http://docs.everypolitician.org/submitting.html