### PR TITLE
Add dummy test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby '2.3.3'
 
 gem 'colorize'
 gem 'field_serializer', github: 'everypolitician/field_serializer'
+gem 'minitest-around'
 gem 'nokogiri'
 gem 'open-uri-cached'
 gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,9 @@ GEM
     httpclient (2.8.3)
     method_source (0.8.2)
     mini_portile2 (2.1.0)
+    minitest (5.10.1)
+    minitest-around (0.4.0)
+      minitest (~> 5.0)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     open-uri-cached (0.0.5)
@@ -87,6 +90,7 @@ PLATFORMS
 DEPENDENCIES
   colorize
   field_serializer!
+  minitest-around
   nokogiri
   open-uri-cached
   pry

--- a/test/dummy_test.rb
+++ b/test/dummy_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative './test_helper'
+
+describe 'dummy test' do
+  it 'should run' do
+    # This test is included to ensure that
+    # test_helper is run by Travis
+  end
+end


### PR DESCRIPTION
This test requires `test_helper` ensure that it is checked by Travis.

The gemfile has been updated to include `minitest-around`