### PR TITLE
Setup check fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+script:
+  - bundle exec rake rubocop
 rvm:
   - 2.3.3
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
-script:
-  - bundle exec rake rubocop
 rvm:
   - 2.3.3
+sudo: false
+cache: bundler
+script:
+  - bundle exec rake
+  - bin/check-fail.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
-script:
-  - bundle exec rake rubocop
 rvm:
   - 2.3.3
 sudo: false

--- a/bin/check-fail.sh
+++ b/bin/check-fail.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Checks tests introduced in pull requests fail on master.
+
+set -eo pipefail
+
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+  echo "Skipping $0 for non-PR build"
+  exit 0
+fi
+
+if echo "${TRAVIS_PULL_REQUEST_BRANCH}" | grep -qi refactor; then
+  echo "The branch name indicates this is a refactoring; skipping this check"
+  exit 0
+fi
+
+target_branch="${TRAVIS_BRANCH}"
+
+if [ -z "${target_branch}" ]; then
+  echo "No target branch found" >&2
+  exit 1
+fi
+
+# Checkout the branch that the pull request is targeting...
+git checkout "${target_branch}"
+
+# ...but revert the test code back to the pull request version
+for dir in t tests test spec; do
+  git checkout "HEAD@{1}" -- "${dir}" 2> /dev/null || true
+done
+
+if bundle exec rake test; then
+  echo "Your newly introduced tests should have failed on ${target_branch}" >&2
+  echo "If you expected them to pass then include 'refactor' in the branch name" >&2
+  exit 1
+else
+  echo "Your new tests failed on ${target_branch}, which is a good thing!"
+fi


### PR DESCRIPTION
This PR configures Travis to run a check-fail script. This script ensures that PRs include passing tests which fail against master. The check-fail script skips branches that include the word 'refactor'. 

Issue: https://github.com/everypolitician/everypolitician/issues/588

This is a step towards scraping the previous term.
Part of: https://github.com/everypolitician/everypolitician-data/issues/26546

(The next step will make a change: MembersPage#member_urls is returning 330 urls (it should be returning 110) because the members are listed in three separate lists on the page. The next commit after that will amend the CSS query to capture from only the alphabetical list.)